### PR TITLE
Change jsDelivr link to exact version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ yarn add nanopop
 
 Include directly via jsdelivr:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/nanopop/lib/nanopop.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/nanopop@1.3.0/lib/nanopop.min.js"></script>
 ```
 
 Using [JavaScript Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules):


### PR DESCRIPTION
jsDelivr recommends not using a the latest version of a library in production (there comment on the home page reads: "omit the version completely to get the latest one, you should NOT use this in production")

This is because a new Major version update could have breaking changes and affect your production app. I'd recommend changing the nanopop README to reflect this best practice